### PR TITLE
Fix uvicorn not starting on fresh install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN touch /var/run/supervisord.pid
 WORKDIR /app/backend
 
 ENV DATA_DIR=/app/data
+ENV PYTHONPATH=/app/backend
 ENV PYTHONUNBUFFERED=1
 
 EXPOSE 80

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -90,6 +90,8 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
+create_db_and_tables()
+
 origins_str = get_config_value("allowed_origins", "*")
 origins = [o.strip() for o in origins_str.split(",")] if origins_str != "*" else ["*"]
 app.add_middleware(

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -8,7 +8,7 @@ logfile_backups=10
 loglevel=info
 
 [program:uvicorn]
-command=python -m uvicorn app.main:app --host 0.0.0.0 --port 8002
+command=uvicorn app.main:app --host 0.0.0.0 --port 8002
 directory=/app/backend
 environment=PYTHONPATH="/app/backend"
 stdout_logfile=/var/log/supervisor/uvicorn.log

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,4 +1,5 @@
 [supervisord]
+user=root
 nodaemon=true
 logfile=/var/log/supervisor/supervisord.log
 pidfile=/var/run/supervisord.pid
@@ -9,6 +10,7 @@ loglevel=info
 [program:uvicorn]
 command=python -m uvicorn app.main:app --host 0.0.0.0 --port 8002
 directory=/app/backend
+environment=PYTHONPATH="/app/backend"
 stdout_logfile=/var/log/supervisor/uvicorn.log
 stderr_logfile=/var/log/supervisor/uvicorn_error.log
 autorestart=true


### PR DESCRIPTION
Executing the compose file resulted in an error.

```
2026-04-02T15:06:00.900668243Z 2026-04-02 15:06:00,900 CRIT Supervisor is running as root.  Privileges were not dropped because no user is specified in the config file.  If you intend to run as root, you can set user=root in the config file to avoid this message.
2026-04-02T15:06:00.902136374Z 2026-04-02 15:06:00,902 INFO supervisord started with pid 1
2026-04-02T15:06:01.905287871Z 2026-04-02 15:06:01,904 INFO spawned: 'uvicorn' with pid 7
2026-04-02T15:06:01.907872381Z 2026-04-02 15:06:01,907 INFO spawned: 'nginx' with pid 8
2026-04-02T15:06:02.902386837Z 2026-04-02 15:06:02,902 WARN exited: uvicorn (exit status 1; not expected)
2026-04-02T15:06:03.904664988Z 2026-04-02 15:06:03,904 INFO spawned: 'uvicorn' with pid 25
2026-04-02T15:06:04.892140201Z 2026-04-02 15:06:04,891 WARN exited: uvicorn (exit status 1; not expected)
2026-04-02T15:06:06.898236424Z 2026-04-02 15:06:06,897 INFO spawned: 'uvicorn' with pid 26
2026-04-02T15:06:07.790856750Z 2026-04-02 15:06:07,790 INFO success: nginx entered RUNNING state, process has stayed up for > than 5 seconds (startsecs)
2026-04-02T15:06:07.890895655Z 2026-04-02 15:06:07,890 WARN exited: uvicorn (exit status 1; not expected)
2026-04-02T15:06:10.894885160Z 2026-04-02 15:06:10,894 INFO spawned: 'uvicorn' with pid 27
2026-04-02T15:06:11.884557150Z 2026-04-02 15:06:11,884 WARN exited: uvicorn (exit status 1; not expected)
2026-04-02T15:06:12.886044084Z 2026-04-02 15:06:12,885 INFO gave up: uvicorn entered FATAL state, too many start retries too quickly
```

These changes should fix it.

