### PR TITLE
Add OpenRouter as a first-class LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,13 +99,14 @@ volumes:
 
 ## LLM Providers
 
-The provider is selected per-model in Settings. Ollama runs locally; OpenAI and Grok require an API key. The vision model can use a different provider than the main LLM — configure it separately via `llm_provider_vision` and `llm_api_key_vision` (e.g. main = Ollama, vision = OpenAI).
+The provider is selected per-model in Settings. Ollama runs locally; OpenAI, Grok, and OpenRouter require an API key. The vision model can use a different provider than the main LLM — configure it separately via `llm_provider_vision` and `llm_api_key_vision` (e.g. main = Ollama, vision = OpenAI).
 
 | Provider | API Base URL | Notes |
 |----------|-------------|-------|
 | Ollama | `http://localhost:11434` | Local — no API key needed |
 | OpenAI | `https://api.openai.com/v1` | Requires API key |
 | Grok (xAI) | `https://api.x.ai/v1` | Requires API key |
+| OpenRouter | `https://openrouter.ai/api/v1` | Requires API key — model uses `vendor/model` namespace (e.g. `anthropic/claude-sonnet-4-6`) |
 
 > OpenAI-compatible endpoints (e.g. LM Studio, vLLM) also work — set the provider to `openai` and point the URL at your local server.
 
@@ -119,6 +120,7 @@ The provider is selected per-model in Settings. Ollama runs locally; OpenAI and 
 | Ollama | `qwen2.5:7b` | Lighter option for slower hardware |
 | OpenAI | `gpt-4o-mini` | Fast and cost-effective |
 | Grok | `grok-3-mini` | xAI alternative |
+| OpenRouter | `anthropic/claude-sonnet-4-6` | Strong general-purpose pick — see [openrouter.ai/models](https://openrouter.ai/models) for the full list |
 
 ### Vision (OCR)
 
@@ -128,6 +130,7 @@ The provider is selected per-model in Settings. Ollama runs locally; OpenAI and 
 | Ollama | `qwen2.5vl:7b` | Good text extraction |
 | OpenAI | `gpt-4o` | Sends PDF natively — all pages at once |
 | Grok | `grok-2-vision-1212` | xAI vision alternative |
+| OpenRouter | `openai/gpt-4o` | Image-based (page-by-page JPEG); PDF-native upload is OpenAI-direct only |
 
 Pull Ollama models before use:
 ```bash

--- a/backend/app/routers/config.py
+++ b/backend/app/routers/config.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 from ..database import get_async_session
 from ..models import Config
 from ..schemas import ConfigResponse, ConfigDetailResponse, ConfigDeleteResponse
+from ..services.llm_handler import OPENAI_COMPATIBLE_PROVIDERS
 from ..services.log_stream import apply_log_level
 
 
@@ -156,7 +157,7 @@ async def test_ollama_connection():
     config = await get_llm_config()
 
     # Test main LLM
-    if config["provider"] in ("openai", "grok"):
+    if config["provider"] in OPENAI_COMPATIBLE_PROVIDERS:
         main_result = await test_openai_url(config["api_base"], config["api_key"])
     else:
         main_result = await test_ollama_url(config["api_base"])
@@ -168,7 +169,7 @@ async def test_ollama_connection():
 
     # Test vision LLM if enabled
     if config["enable_vision"]:
-        if config["provider_vision"] in ("openai", "grok"):
+        if config["provider_vision"] in OPENAI_COMPATIBLE_PROVIDERS:
             vision_result = await test_openai_url(
                 config["api_base_vision"], config["api_key_vision"]
             )

--- a/backend/app/services/llm_handler.py
+++ b/backend/app/services/llm_handler.py
@@ -1,4 +1,9 @@
-"""LLM client supporting Ollama and OpenAI-compatible APIs (including Grok).
+"""LLM client supporting Ollama and OpenAI-compatible APIs.
+
+Supported providers: Ollama, OpenAI, Grok (xAI), OpenRouter. The OpenAI-
+compatible providers share the ``/chat/completions`` path; OpenRouter adds
+``HTTP-Referer`` and ``X-Title`` headers for attribution and rate-limit
+scoping.
 
 Provides text completion (with optional JSON mode) and vision multimodal
 completion. LLMHandler instances are managed by the singleton LLMHandlerManager.
@@ -13,13 +18,19 @@ from ..exceptions import LLMUnavailableError
 
 logger = logging.getLogger(__name__)
 
+OPENAI_COMPATIBLE_PROVIDERS = frozenset({"openai", "grok", "openrouter"})
+
+OPENROUTER_REFERER = "https://github.com/nyxtron/paperless-aissist"
+OPENROUTER_TITLE = "Paperless-AIssist"
+
 
 class LLMHandler:
     """HTTP client for LLM inference via Ollama or OpenAI-compatible APIs.
 
     Attributes:
-        provider: "ollama", "openai", or "grok".
-        model: Model name passed to the API.
+        provider: ``ollama``, ``openai``, ``grok``, or ``openrouter``.
+        model: Model name passed to the API. For OpenRouter, use the
+            ``vendor/model`` namespace form (e.g. ``anthropic/claude-sonnet-4-6``).
         api_base: Base URL for the API endpoint.
         api_key: Optional API key for authenticated endpoints.
         timeout: Request timeout in seconds.
@@ -47,6 +58,11 @@ class LLMHandler:
             headers = {"Content-Type": "application/json"}
             if self.api_key:
                 headers["Authorization"] = f"Bearer {self.api_key}"
+            if self.provider == "openrouter":
+                # OpenRouter uses these for app attribution and per-app rate limits.
+                # See https://openrouter.ai/docs/api-reference/overview#headers
+                headers["HTTP-Referer"] = OPENROUTER_REFERER
+                headers["X-Title"] = OPENROUTER_TITLE
             self._client = httpx.AsyncClient(
                 base_url=self.api_base,
                 timeout=self.timeout,
@@ -92,7 +108,11 @@ class LLMHandler:
         if not provider:
             provider = "ollama"
         if not model:
-            model = "llama3" if not for_vision else "llava"
+            if provider == "openrouter":
+                # OpenRouter requires the vendor/model namespace form.
+                model = "openai/gpt-4o-mini" if not for_vision else "openai/gpt-4o"
+            else:
+                model = "llama3" if not for_vision else "llava"
 
         timeout_str = await cls._get_config(f"llm_timeout{suffix}")
         if for_vision and not timeout_str:
@@ -138,7 +158,7 @@ class LLMHandler:
             return await self._ollama_complete(
                 system_prompt, user_prompt, json_mode, temperature
             )
-        elif self.provider in ("openai", "grok"):
+        elif self.provider in OPENAI_COMPATIBLE_PROVIDERS:
             return await self._openai_complete(
                 system_prompt, user_prompt, json_mode, temperature
             )
@@ -278,13 +298,15 @@ class LLMHandler:
             return await self._ollama_vision_complete(
                 system_prompt, user_prompt, images, json_mode, temperature
             )
-        elif self.provider in ("openai", "grok"):
+        elif self.provider in OPENAI_COMPATIBLE_PROVIDERS:
             return await self._openai_vision_complete(
                 system_prompt,
                 user_prompt,
                 images,
                 json_mode,
                 temperature,
+                # PDF-native file upload is an OpenAI-only capability. Grok and
+                # OpenRouter (which proxies many backends) fall back to JPEGs.
                 pdf_bytes=pdf_bytes if self.provider == "openai" else None,
             )
         else:

--- a/backend/tests/test_llm_handler_openrouter.py
+++ b/backend/tests/test_llm_handler_openrouter.py
@@ -1,0 +1,167 @@
+"""Tests for OpenRouter provider support in LLMHandler.
+
+Covers:
+- HTTP-Referer / X-Title attribution headers on the httpx client
+- Dispatch through the OpenAI-compatible code path (text + vision)
+- Sensible defaults from from_config when only the provider is set
+- Non-openrouter providers do NOT get the OpenRouter headers
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.llm_handler import (
+    OPENAI_COMPATIBLE_PROVIDERS,
+    OPENROUTER_REFERER,
+    OPENROUTER_TITLE,
+    LLMHandler,
+)
+
+
+def test_openrouter_is_openai_compatible():
+    """The shared provider set must include openrouter so test endpoints route correctly."""
+    assert "openrouter" in OPENAI_COMPATIBLE_PROVIDERS
+    assert "openai" in OPENAI_COMPATIBLE_PROVIDERS
+    assert "grok" in OPENAI_COMPATIBLE_PROVIDERS
+
+
+def test_openrouter_client_has_attribution_headers():
+    """OpenRouter requests carry HTTP-Referer and X-Title for app attribution."""
+    handler = LLMHandler(
+        provider="openrouter",
+        model="anthropic/claude-sonnet-4-6",
+        api_base="https://openrouter.ai/api/v1",
+        api_key="sk-or-test",
+    )
+    headers = handler.client.headers
+    assert headers["HTTP-Referer"] == OPENROUTER_REFERER
+    assert headers["X-Title"] == OPENROUTER_TITLE
+    assert headers["Authorization"] == "Bearer sk-or-test"
+
+
+def test_openai_provider_does_not_get_openrouter_headers():
+    """Plain OpenAI must not leak OpenRouter-specific headers."""
+    handler = LLMHandler(
+        provider="openai",
+        model="gpt-4o-mini",
+        api_base="https://api.openai.com/v1",
+        api_key="sk-test",
+    )
+    headers = handler.client.headers
+    assert "HTTP-Referer" not in headers
+    assert "X-Title" not in headers
+
+
+def test_grok_provider_does_not_get_openrouter_headers():
+    """Grok must not leak OpenRouter-specific headers either."""
+    handler = LLMHandler(
+        provider="grok",
+        model="grok-3-mini",
+        api_base="https://api.x.ai/v1",
+        api_key="xai-test",
+    )
+    headers = handler.client.headers
+    assert "HTTP-Referer" not in headers
+    assert "X-Title" not in headers
+
+
+@pytest.mark.asyncio
+async def test_openrouter_complete_routes_through_openai_path():
+    """Text completion for openrouter must hit _openai_complete, not _ollama_complete."""
+    handler = LLMHandler(provider="openrouter", model="openai/gpt-4o-mini")
+    with (
+        patch.object(
+            handler, "_openai_complete", AsyncMock(return_value={"text": "ok"})
+        ) as openai_mock,
+        patch.object(
+            handler, "_ollama_complete", AsyncMock(return_value={"text": "wrong"})
+        ) as ollama_mock,
+    ):
+        result = await handler.complete("sys", "user")
+
+    assert result == {"text": "ok"}
+    openai_mock.assert_awaited_once()
+    ollama_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_openrouter_vision_routes_through_openai_vision_path():
+    """Vision completion for openrouter must hit _openai_vision_complete with no pdf_bytes."""
+    handler = LLMHandler(provider="openrouter", model="openai/gpt-4o")
+    with patch.object(
+        handler,
+        "_openai_vision_complete",
+        AsyncMock(return_value={"text": "ok"}),
+    ) as vision_mock:
+        await handler.vision_complete(
+            "sys",
+            user_prompt="user",
+            images=[b"jpg-bytes"],
+            pdf_bytes=b"pdf-bytes",
+        )
+
+    vision_mock.assert_awaited_once()
+    # pdf_bytes must be stripped for non-openai providers — OpenRouter proxies many
+    # backends and PDF-native upload is OpenAI-direct only.
+    _, kwargs = vision_mock.call_args
+    assert kwargs["pdf_bytes"] is None
+
+
+@pytest.mark.asyncio
+async def test_openai_vision_keeps_pdf_bytes():
+    """Sanity check: openai provider still receives pdf_bytes natively."""
+    handler = LLMHandler(provider="openai", model="gpt-4o")
+    with patch.object(
+        handler,
+        "_openai_vision_complete",
+        AsyncMock(return_value={"text": "ok"}),
+    ) as vision_mock:
+        await handler.vision_complete(
+            "sys",
+            images=[b"jpg-bytes"],
+            pdf_bytes=b"pdf-bytes",
+        )
+
+    _, kwargs = vision_mock.call_args
+    assert kwargs["pdf_bytes"] == b"pdf-bytes"
+
+
+@pytest.mark.asyncio
+async def test_openrouter_from_config_uses_namespaced_default_model():
+    """When only provider=openrouter is configured, default model uses vendor/model namespace."""
+    configs = {
+        "llm_provider": "openrouter",
+        "llm_model": None,
+        "llm_api_base": "https://openrouter.ai/api/v1",
+        "llm_api_key": "sk-or-test",
+    }
+
+    async def fake_get_config(key: str):
+        return configs.get(key)
+
+    with patch.object(LLMHandler, "_get_config", side_effect=fake_get_config):
+        handler = await LLMHandler.from_config(for_vision=False)
+
+    assert handler.provider == "openrouter"
+    assert handler.model == "openai/gpt-4o-mini"
+
+
+@pytest.mark.asyncio
+async def test_openrouter_from_config_vision_default_model():
+    """Vision default for openrouter also uses vendor/model namespace."""
+    configs = {
+        "llm_provider_vision": "openrouter",
+        "llm_model_vision": None,
+        "llm_api_base_vision": "https://openrouter.ai/api/v1",
+        "llm_api_key_vision": "sk-or-test",
+    }
+
+    async def fake_get_config(key: str):
+        return configs.get(key)
+
+    with patch.object(LLMHandler, "_get_config", side_effect=fake_get_config):
+        handler = await LLMHandler.from_config(for_vision=True)
+
+    assert handler.provider == "openrouter"
+    assert handler.model == "openai/gpt-4o"

--- a/frontend/src/components/ConfigSectionLLM.tsx
+++ b/frontend/src/components/ConfigSectionLLM.tsx
@@ -41,12 +41,14 @@ export function ConfigSectionLLM({ config, onSave, secretsSet }: ConfigSectionPr
   const getModelPlaceholder = (provider: string) => {
     if (provider === 'openai') return 'gpt-4o-mini'
     if (provider === 'grok') return 'grok-3-mini'
+    if (provider === 'openrouter') return 'openai/gpt-4o-mini'
     return 'qwen2.5:7b'
   }
 
   const getApiBasePlaceholder = (provider: string) => {
     if (provider === 'openai') return 'https://api.openai.com/v1'
     if (provider === 'grok') return 'https://api.x.ai/v1'
+    if (provider === 'openrouter') return 'https://openrouter.ai/api/v1'
     return 'http://localhost:11434'
   }
 
@@ -83,6 +85,7 @@ export function ConfigSectionLLM({ config, onSave, secretsSet }: ConfigSectionPr
             <option value="ollama">Ollama</option>
             <option value="openai">OpenAI</option>
             <option value="grok">Grok (xAI)</option>
+            <option value="openrouter">OpenRouter</option>
           </select>
         </div>
         <div>

--- a/frontend/src/components/ConfigSectionVision.tsx
+++ b/frontend/src/components/ConfigSectionVision.tsx
@@ -13,12 +13,14 @@ export function ConfigSectionVision({ config, onSave, secretsSet }: ConfigSectio
   const getVisionModelPlaceholder = (provider: string) => {
     if (provider === 'openai') return 'gpt-4o'
     if (provider === 'grok') return 'grok-2-vision-1212'
+    if (provider === 'openrouter') return 'openai/gpt-4o'
     return 'qwen2.5vl:7b'
   }
 
   const getApiBasePlaceholder = (provider: string) => {
     if (provider === 'openai') return 'https://api.openai.com/v1'
     if (provider === 'grok') return 'https://api.x.ai/v1'
+    if (provider === 'openrouter') return 'https://openrouter.ai/api/v1'
     return 'http://localhost:11434'
   }
 
@@ -52,6 +54,7 @@ export function ConfigSectionVision({ config, onSave, secretsSet }: ConfigSectio
             <option value="ollama">Ollama</option>
             <option value="openai">OpenAI</option>
             <option value="grok">Grok (xAI)</option>
+            <option value="openrouter">OpenRouter</option>
           </select>
         </div>
         <div>


### PR DESCRIPTION
## Summary

Adds OpenRouter (`https://openrouter.ai/api/v1`) as a first-class provider alongside Ollama / OpenAI / Grok. OpenRouter is OpenAI-compatible, so the existing `/chat/completions` code path is reused — but three things were missing for a clean integration:

1. **Centralized provider set.** `OPENAI_COMPATIBLE_PROVIDERS = frozenset({"openai", "grok", "openrouter"})` in `llm_handler.py` replaces three scattered `("openai", "grok")` tuples. Adding the next compatible provider is now one set entry, not three call-site edits.
2. **Attribution headers.** `HTTP-Referer` and `X-Title` are sent on OpenRouter requests per [their docs](https://openrouter.ai/docs/api-reference/overview#headers). These power the OpenRouter app-attribution leaderboard and per-app rate-limit scoping. Without them, requests are anonymous.
3. **Provider-aware default model.** OpenRouter uses `vendor/model` namespaces — `openai/gpt-4o-mini`, `anthropic/claude-sonnet-4-6`. The previous default `llama3` / `llava` would 404 there.

PDF-native vision upload stays OpenAI-direct only — OpenRouter proxies many vendor backends and the file-upload payload is not portable. Grok and OpenRouter both fall back to per-page JPEG vision (same as Grok already did).

## Changes

- `backend/app/services/llm_handler.py` — provider set + OpenRouter headers in the httpx client + namespaced default model.
- `backend/app/routers/config.py` — imports the central set; `test-ollama` endpoint routes OpenRouter through the OpenAI-compatible test path.
- `frontend/src/components/ConfigSectionLLM.tsx` + `ConfigSectionVision.tsx` — provider dropdown gets the OpenRouter option, placeholders show the namespaced model form (`openai/gpt-4o-mini`, `openai/gpt-4o`) and the correct API base.
- `README.md` — OpenRouter row in the providers table + recommended model rows for text and vision.
- `backend/tests/test_llm_handler_openrouter.py` — 9 new unit tests:
  - attribution headers present on `openrouter` client, absent on `openai` / `grok`
  - `complete()` routes openrouter through `_openai_complete`
  - `vision_complete()` routes openrouter through `_openai_vision_complete` and **strips `pdf_bytes`** (since OpenRouter can't guarantee native PDF support)
  - sanity: `openai` provider still receives `pdf_bytes`
  - `from_config` defaults to `openai/gpt-4o-mini` for text and `openai/gpt-4o` for vision when only the provider is set

## Test plan

- [x] `pytest backend/tests/` — 118 passed, 3 skipped, 0 failed locally
- [x] `npm test` in frontend/ — 70 passed
- [x] `npm run build` in frontend/ — clean TypeScript build
- [ ] Manual: set provider=openrouter + api_key + model `anthropic/claude-sonnet-4-6` in Settings → "Test Connection" returns connected + lists models
- [ ] Manual: run a real `ai-process` against an OpenRouter model and verify the request shows up under the configured app in [openrouter.ai/activity](https://openrouter.ai/activity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)