### PR TITLE
Fix chat document search result limit

### DIFF
--- a/backend/app/routers/documents.py
+++ b/backend/app/routers/documents.py
@@ -70,7 +70,7 @@ async def search_documents(query: str = Query(..., max_length=500)):
                 "title": doc.get("title"),
                 "created": doc.get("created"),
             }
-            for doc in docs[:5]
+            for doc in docs
         ]
         return {"results": results}
     except Exception as e:

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -220,7 +220,7 @@ export default function ChatPage() {
               searchResults.length === 0 ? (
                 <div className="p-4 text-sm text-gray-500 text-center">{t('chat.noResults')}</div>
               ) : (
-                searchResults.slice(0, 5).map((doc) => (
+                searchResults.map((doc) => (
                   <button
                     key={doc.id}
                     onClick={() => selectDocument(doc.id)}


### PR DESCRIPTION
## Summary

the document search on the Chat page only ever showed 5 results, even when more documents matched. this removes that cap so all matching documents show up.

Fixes #31

## Root cause

the limit was actually in two places:

1. backend (`backend/app/routers/documents.py`): the `/documents/search` endpoint sliced results with `docs[:5]` before returning, so the API itself never sent back more than 5.
2. frontend (`frontend/src/pages/ChatPage.tsx`): the results were sliced again with `searchResults.slice(0, 5)` before rendering.

the reporter mentioned the API debug looked correct but only 5 came back, which lines up with the backend being the main culprit. just fixing the frontend wouldnt have been enough since the backend was already capping the response.

## Changes

- removed `docs[:5]` in the backend search endpoint.
- removed `.slice(0, 5)` in the frontend chat search.

the results container already has `overflow-y-auto`, so longer lists just scroll. pagination in `list_documents` still applies, so this doesnt pull an unbounded number of documents.

## Testing

tested locally with 7 documents that all match the term "invoice":

- before: only 5 results showed.
- after: all matching documents show.

checked both the backend endpoint directly and the chat UI. before/after screenshots below.

# Before
<img width="500" height="500" alt="8b345e5f-dc5e-44d2-9683-c9b606c8a615" src="https://github.com/user-attachments/assets/529fcfda-aaf4-439e-9a77-09dc90b4a8a6" />


# After
<img width="1280" height="900" alt="4d10395d-e0dd-4145-bd15-d312855bb257" src="https://github.com/user-attachments/assets/e85d24e7-831e-4865-ba29-5bc6dd967780" />

